### PR TITLE
Update GitHub Actions to Node.js 24-compatible action versions

### DIFF
--- a/.github/workflows/deploy-ftp.yml
+++ b/.github/workflows/deploy-ftp.yml
@@ -9,12 +9,12 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v4.4.0
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
 
       - name: Install dependencies


### PR DESCRIPTION
- actions/checkout@v4 → v4.2.2
- actions/setup-node@v4 → v4.4.0, node-version 20 → 24

Avoids deprecation warnings ahead of the June 2026 Node.js 24 default.